### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -1,4 +1,4 @@
-var config, ent, esprima, evalFnCache, evaluate, expressionCache, i, _,
+var config, he, esprima, evalFnCache, evaluate, expressionCache, i, _,
   __slice = [].slice;
 
 esprima = require('esprima');
@@ -9,7 +9,7 @@ _ = require('lodash');
 
 evaluate = require('static-eval');
 
-ent = require('ent');
+he = require('he');
 
 expressionCache = {};
 
@@ -40,7 +40,7 @@ module.exports = {
     if (thisArg == null) {
       thisArg = context;
     }
-    expression = ent.decode(expression);
+    expression = he.decode(expression);
     fn = evalFnCache[expression] || (evalFnCache[expression] = new Function('context', "with (context) { return " + expression + " }"));
     try {
       output = fn.call(thisArg, context);
@@ -65,7 +65,7 @@ module.exports = {
     if (thisArg == null) {
       thisArg = this;
     }
-    expression = ent.decode(expression);
+    expression = he.decode(expression);
     context['this'] = thisArg;
     try {
       expressionBody = expressionCache[expression] || ((_ref = esprima.parse(expression).body[0]) != null ? _ref.expression : void 0);

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -2,7 +2,7 @@ esprima = require 'esprima'
 config = require './config'
 _ = require 'lodash'
 evaluate = require 'static-eval'
-ent = require 'ent'
+he = require 'he'
 
 expressionCache = {}
 evalFnCache = {}
@@ -17,7 +17,7 @@ module.exports =
     console.info args... if config.verbose
 
   safeEvalWithContext: (expression = '', context, clone, thisArg = context, returnNewContext) ->
-    expression = ent.decode expression
+    expression = he.decode expression
 
     fn = evalFnCache[expression] or= new Function 'context', "with (context) { return #{expression} }"
     try
@@ -34,7 +34,7 @@ module.exports =
   # In Java can use ScriptEngineManager to eval js
   # (http://stackoverflow.com/questions/2605032/using-eval-in-java)
   safeEvalStaticExpression: (expression = '', context, thisArg = @) ->
-    expression = ent.decode expression
+    expression = he.decode expression
 
     context['this'] = thisArg
     try

--- a/package.json
+++ b/package.json
@@ -15,19 +15,19 @@
   "bin": {
     "compylr": "./bin/compylr"
   },
-  "licsense": "MIT",
+  "license": "MIT",
   "dependencies": {
-    "optimist": "~0.6.0",
-    "js-beautify": "~1.4.2",
+    "esprima": "~1.0.4",
+    "glob": "~3.2.8",
     "handlebars": "~1.3.0",
+    "he": "~0.4.1",
+    "js-beautify": "~1.4.2",
     "lodash": "~2.4.1",
     "mkdirp": "~0.3.5",
-    "static-eval": "~0.1.0",
-    "esprima": "~1.0.4",
+    "optimist": "~0.6.0",
     "request": "~2.31.0",
-    "underscore.string": "~2.3.3",
-    "glob": "~3.2.8",
-    "ent": "~2.0.0"
+    "static-eval": "~0.1.0",
+    "underscore.string": "~2.3.3"
   },
   "devDependencies": {
     "coffee-script": "~1.6.3",


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](http://mths.be/he).
