### PR TITLE
Fix bug where one letter {{}} expressions would parse strangely.

### DIFF
--- a/dist/compile.js
+++ b/dist/compile.js
@@ -378,7 +378,7 @@ compile = function(options) {
     if (i++ > maxIters) {
       throw new Error('infinite update loop');
     }
-    interpolated = interpolated.replace(/\{\{([^#\/>_][\s\S]*?[^_])\}\}/g, function(match, body) {
+    interpolated = interpolated.replace(/\{\{([a-zA-Z]|[^#\/>_][\s\S]*?[^_])\}\}/g, function(match, body) {
       var isHelper, prefix, suffix, words, _ref;
       helpers.logVerbose('match 7');
       updated = true;

--- a/lib/compile.coffee
+++ b/lib/compile.coffee
@@ -478,7 +478,7 @@ compile = (options) ->
 
       # {{interpolation}}, {{exression == true}} -
 
-      .replace(/\{\{([^#\/>_][\s\S]*?[^_])\}\}/g, (match, body) ->
+      .replace(/\{\{([a-zA-Z]|[^#\/>_][\s\S]*?[^_])\}\}/g, (match, body) ->
         helpers.logVerbose 'match 7'
         updated = true
         body = body.trim()


### PR DESCRIPTION
Fixes bug where this template would fail to parse correclty.

```html
<ul>
	<li ng-repeat="a in list">{{a}}</li>
</ul>
```